### PR TITLE
Improve simulator startup and logging

### DIFF
--- a/PriceImpactSimulator.Engine/MarketSimulator.cs
+++ b/PriceImpactSimulator.Engine/MarketSimulator.cs
@@ -87,7 +87,7 @@ public sealed class MarketSimulator
         {
             var priceOffset = Math.Abs(RandomNormal(0, 1.5));
             var signedOff = side == Side.Buy ? -priceOffset : priceOffset;
-            var midBase = _book.Mid ?? 20.00m;
+            var midBase = _book.Mid ?? _startMid;
             var price = Math.Round(midBase + (decimal)signedOff * _p.TickSize, 2);
 
 

--- a/PriceImpactSimulator.Engine/MarketSimulator.cs
+++ b/PriceImpactSimulator.Engine/MarketSimulator.cs
@@ -163,7 +163,7 @@ public sealed class MarketSimulator
             foreach (var ord in _book.OrdersAtPrice(side, price))
             {
                 if (excess <= 0) break;
-                _book.Cancel(ord.Id, ts);
+                foreach (var _ in _book.Cancel(ord.Id, ts)) { }
                 excess -= ord.Quantity;
             }
 

--- a/PriceImpactSimulator.Engine/MarketSimulator.cs
+++ b/PriceImpactSimulator.Engine/MarketSimulator.cs
@@ -33,9 +33,9 @@ public sealed class MarketSimulator
             var bidPrice = _startMid - (lvl + 1) * _p.TickSize;
 
             _book.AddLimit(new Order(Guid.NewGuid(), DateTime.UtcNow,
-                Side.Sell, askPrice, vol, OrderType.Limit, null));
+                Side.Sell, askPrice, vol, OrderType.Limit, null), DateTime.UtcNow);
             _book.AddLimit(new Order(Guid.NewGuid(), DateTime.UtcNow,
-                Side.Buy, bidPrice, vol, OrderType.Limit, null));
+                Side.Buy, bidPrice, vol, OrderType.Limit, null), DateTime.UtcNow);
         }
     }
 
@@ -93,14 +93,10 @@ public sealed class MarketSimulator
 
 
             var order = new Order(Guid.NewGuid(), ts, side, price, qty, OrderType.Limit, null);
-            _book.AddLimit(order);
-            var newExec = new ExecutionReport(
-                order.Id, ExecType.New, side,
-                price,
-                0, qty, ts);
+            var (exs, trs) = _book.AddLimit(order, ts);
 
             UpdateMidHistory(ts);
-            return (new[] { newExec }, Array.Empty<Trade>(), cancelReports);
+            return (exs, trs, cancelReports);
         }
 
         // local helpers ----------
@@ -153,7 +149,7 @@ public sealed class MarketSimulator
         if (current < targetQty)
         {
             _book.AddLimit(new Order(Guid.NewGuid(), ts, side, price,
-                targetQty - current, OrderType.Limit, null));
+                targetQty - current, OrderType.Limit, null), ts);
             return;
         }
 
@@ -170,7 +166,7 @@ public sealed class MarketSimulator
             if (excess < 0)
             {
                 _book.AddLimit(new Order(Guid.NewGuid(), ts, side, price,
-                    -excess, OrderType.Limit, null));
+                    -excess, OrderType.Limit, null), ts);
             }
         }
     }

--- a/PriceImpactSimulator.Engine/OrderBook.cs
+++ b/PriceImpactSimulator.Engine/OrderBook.cs
@@ -27,6 +27,9 @@ public sealed class OrderBook
         }
     }
 
+    internal SortedDictionary<decimal, Queue<Order>> BidsInternal => _bids;
+    internal SortedDictionary<decimal, Queue<Order>> AsksInternal => _asks;
+
 
     #region Public API ------------------------------------------------------
 

--- a/PriceImpactSimulator.Engine/OrderBook.cs
+++ b/PriceImpactSimulator.Engine/OrderBook.cs
@@ -42,6 +42,18 @@ public sealed class OrderBook
         _index[order.Id] = (order.Price, order.Side);
     }
 
+    public int QuantityAt(Side side, decimal price)
+    {
+        var book = side == Side.Buy ? _bids : _asks;
+        return book.TryGetValue(price, out var q) ? q.Sum(o => o.Quantity) : 0;
+    }
+
+    public Order[] OrdersAtPrice(Side side, decimal price)
+    {
+        var book = side == Side.Buy ? _bids : _asks;
+        return book.TryGetValue(price, out var q) ? q.ToArray() : Array.Empty<Order>();
+    }
+
     public IEnumerable<ExecutionReport> Cancel(Guid orderId, DateTime ts)
     {
         if (!_index.TryGetValue(orderId, out var meta))

--- a/PriceImpactSimulator.Engine/OrderBook.cs
+++ b/PriceImpactSimulator.Engine/OrderBook.cs
@@ -114,10 +114,10 @@ public sealed class OrderBook
 
     public OrderBookSnapshot Snapshot(DateTime ts, int depthLevels)
     {
-        static OrderBookLevel[] TakeLevels(SortedDictionary<decimal, Queue<Order>> src, bool desc, int n)
+        static OrderBookLevel[] TakeLevels(IEnumerable<KeyValuePair<decimal, Queue<Order>>> src, int n)
         {
             var arr = new List<OrderBookLevel>(n);
-            foreach (var kv in desc ? src : src)
+            foreach (var kv in src)
             {
                 arr.Add(new OrderBookLevel(kv.Key, kv.Value.Sum(o => o.Quantity)));
                 if (arr.Count == n) break;
@@ -128,8 +128,8 @@ public sealed class OrderBook
         return new OrderBookSnapshot
         {
             Timestamp = ts,
-            Bids = TakeLevels(_bids, true, depthLevels),
-            Asks = TakeLevels(_asks, false, depthLevels)
+            Bids = TakeLevels(_bids, depthLevels),
+            Asks = TakeLevels(_asks, depthLevels)
         };
     }
 

--- a/PriceImpactSimulator.Host/MultiStrategy.cs
+++ b/PriceImpactSimulator.Host/MultiStrategy.cs
@@ -1,0 +1,32 @@
+﻿using PriceImpactSimulator.Domain;
+using PriceImpactSimulator.StrategyApi;
+
+namespace PriceImpactSimulator.Host;
+
+public sealed class MultiStrategy : IStrategy
+{
+    private readonly IStrategy[] _strategies;
+    public MultiStrategy(params IStrategy[] strats) => _strategies = strats;
+
+    public void Initialize(in StrategyContext ctx)
+    {
+        foreach (var s in _strategies) s.Initialize(ctx);
+    }
+
+    public void OnOrderBook(in OrderBookSnapshot snap)
+    {
+        foreach (var s in _strategies) s.OnOrderBook(snap);
+    }
+
+    public void OnExecution(in ExecutionReport rep)
+    {
+        foreach (var s in _strategies) s.OnExecution(rep);
+    }
+
+    public IReadOnlyList<OrderCommand> GenerateCommands(DateTime nowUtc)
+    {
+        var list = new List<OrderCommand>();
+        foreach (var s in _strategies) list.AddRange(s.GenerateCommands(nowUtc));
+        return list;
+    }
+}

--- a/PriceImpactSimulator.Host/SimulationRunner.cs
+++ b/PriceImpactSimulator.Host/SimulationRunner.cs
@@ -70,7 +70,7 @@ public sealed class SimulationRunner
             if (now >= nextBookDump)
             {
                 _sink.LogBook(snap);
-                nextBookDump = now + TimeSpan.FromSeconds(10);
+                nextBookDump = now + TimeSpan.FromSeconds(2);
             }
 
             if (now >= nextStats && _strategy is IStrategyWithStats s)
@@ -80,12 +80,6 @@ public sealed class SimulationRunner
                 nextStats = now + TimeSpan.FromSeconds(2);
             }
 
-            // исполнение наших приказов
-            /* примечание: для «нулевой» стратегии список пуст, 
-               в MomentumIgnitor мы будем проверять exec.Side совпадает с нашими Id */
-            // ...
-
-            // стратегия выдаёт команды
             var cmds = _strategy.GenerateCommands(now);
             foreach (var cmd in cmds) Apply(cmd, now);
 

--- a/PriceImpactSimulator.Host/SimulationRunner.cs
+++ b/PriceImpactSimulator.Host/SimulationRunner.cs
@@ -37,6 +37,7 @@ public sealed class SimulationRunner
     {
         var now = DateTime.UtcNow;
         var end = now + duration;
+        var nextBookDump = now;
 
         while (now < end)
         {
@@ -50,6 +51,12 @@ public sealed class SimulationRunner
             // книга → стратегия
             var snap = _book.Snapshot(now, depthLevels: 10);
             _strategy.OnOrderBook(snap);
+
+            if (now >= nextBookDump)
+            {
+                _sink.LogBook(snap);
+                nextBookDump = now + TimeSpan.FromSeconds(10);
+            }
 
             // исполнение наших приказов
             /* примечание: для «нулевой» стратегии список пуст, 

--- a/PriceImpactSimulator.Host/SimulationRunner.cs
+++ b/PriceImpactSimulator.Host/SimulationRunner.cs
@@ -103,15 +103,13 @@ public sealed class SimulationRunner
             case CommandType.New:
                 var order = new Order(cmd.OrderId, ts, cmd.Side, cmd.Price,
                                       cmd.Quantity, OrderType.Limit, null);
-                _book.AddLimit(order);
-                _sink.LogExec(new ExecutionReport(
-                    order.Id, ExecType.New, order.Side,
-                    order.Price,
-                    0, cmd.Quantity, ts));
-                _strategy.OnExecution(new ExecutionReport(
-                    order.Id, ExecType.New, order.Side,
-                    order.Price, 0, cmd.Quantity, ts));
-
+                var (execs, trades) = _book.AddLimit(order, ts);
+                foreach (var tr in trades) _sink.LogTrade(tr);
+                foreach (var ex in execs)
+                {
+                    _sink.LogExec(ex);
+                    _strategy.OnExecution(ex);
+                }
                 break;
 
             case CommandType.Cancel:

--- a/PriceImpactSimulator.Persistence/CsvSink.cs
+++ b/PriceImpactSimulator.Persistence/CsvSink.cs
@@ -1,4 +1,5 @@
 ﻿// File: CsvSink.cs
+
 using System;
 using System.Globalization;
 using System.IO;
@@ -56,12 +57,14 @@ public sealed class CsvSink : IDisposable
         for (int i = 0; i < depth; i++)
         {
             string bidPrice = i < snap.Bids.Length ? snap.Bids[i].Price.ToString("F2") : string.Empty;
-            string bidQty   = i < snap.Bids.Length ? snap.Bids[i].Quantity.ToString() : string.Empty;
+            string bidQty = i < snap.Bids.Length ? snap.Bids[i].Quantity.ToString() : string.Empty;
             string askPrice = i < snap.Asks.Length ? snap.Asks[i].Price.ToString("F2") : string.Empty;
-            string askQty   = i < snap.Asks.Length ? snap.Asks[i].Quantity.ToString() : string.Empty;
+            string askQty = i < snap.Asks.Length ? snap.Asks[i].Quantity.ToString() : string.Empty;
 
             _books.WriteLine($"{snap.Timestamp:O},{bidPrice},{bidQty},{askPrice},{askQty}");
         }
+
+        _books.WriteLine($"                                   ");
     }
 
     public void LogEvent(string message)

--- a/PriceImpactSimulator.Persistence/CsvSink.cs
+++ b/PriceImpactSimulator.Persistence/CsvSink.cs
@@ -25,7 +25,7 @@ public sealed class CsvSink : IDisposable
         _orders = Create(Path.Combine(folderUtc, $"orders_{stamp}.csv"),
             "ts,orderId,execType,side,price,lastQty,leaves");
         _books = Create(Path.Combine(folderUtc, $"book_{stamp}.csv"),
-            "ts,side,price,qty");
+            "ts,bidPrice,bidQty,askPrice,askQty");
 
         static StreamWriter Create(string path, string header)
         {
@@ -46,10 +46,16 @@ public sealed class CsvSink : IDisposable
 
     public void LogBook(in OrderBookSnapshot snap)
     {
-        foreach (var l in snap.Bids)
-            _books.WriteLine($"{snap.Timestamp:O},Bid,{l.Price:F2},{l.Quantity}");
-        foreach (var l in snap.Asks)
-            _books.WriteLine($"{snap.Timestamp:O},Ask,{l.Price:F2},{l.Quantity}");
+        var depth = Math.Max(snap.Bids.Length, snap.Asks.Length);
+        for (int i = 0; i < depth; i++)
+        {
+            string bidPrice = i < snap.Bids.Length ? snap.Bids[i].Price.ToString("F2") : string.Empty;
+            string bidQty   = i < snap.Bids.Length ? snap.Bids[i].Quantity.ToString() : string.Empty;
+            string askPrice = i < snap.Asks.Length ? snap.Asks[i].Price.ToString("F2") : string.Empty;
+            string askQty   = i < snap.Asks.Length ? snap.Asks[i].Quantity.ToString() : string.Empty;
+
+            _books.WriteLine($"{snap.Timestamp:O},{bidPrice},{bidQty},{askPrice},{askQty}");
+        }
     }
 
     // ---------- housekeeping ----------

--- a/PriceImpactSimulator.Persistence/CsvSink.cs
+++ b/PriceImpactSimulator.Persistence/CsvSink.cs
@@ -13,6 +13,8 @@ public sealed class CsvSink : IDisposable
     private readonly StreamWriter _trades;
     private readonly StreamWriter _orders;
     private readonly StreamWriter _books;
+    private readonly StreamWriter _events;
+    private readonly StreamWriter _stats;
 
     public CsvSink(string folderUtc)
     {
@@ -24,8 +26,12 @@ public sealed class CsvSink : IDisposable
             "ts,side,price,qty");
         _orders = Create(Path.Combine(folderUtc, $"orders_{stamp}.csv"),
             "ts,orderId,execType,side,price,lastQty,leaves");
-        _books = Create(Path.Combine(folderUtc, $"book_{stamp}.csv"),
+        _books  = Create(Path.Combine(folderUtc, $"book_{stamp}.csv"),
             "ts,bidPrice,bidQty,askPrice,askQty");
+        _events = Create(Path.Combine(folderUtc, $"events_{stamp}.csv"),
+            "ts,message");
+        _stats  = Create(Path.Combine(folderUtc, $"stats_{stamp}.csv"),
+            "ts,buyPower,position,vwap,pnl");
 
         static StreamWriter Create(string path, string header)
         {
@@ -58,11 +64,19 @@ public sealed class CsvSink : IDisposable
         }
     }
 
+    public void LogEvent(string message)
+        => _events.WriteLine($"{DateTime.UtcNow:O},{message}");
+
+    public void LogStats(DateTime ts, decimal buyPower, int pos, decimal vwap, decimal pnl)
+        => _stats.WriteLine($"{ts:O},{buyPower:F2},{pos},{vwap:F2},{pnl:F2}");
+
     // ---------- housekeeping ----------
     public void Dispose()
     {
         _trades.Dispose();
         _orders.Dispose();
         _books.Dispose();
+        _events.Dispose();
+        _stats.Dispose();
     }
 }

--- a/PriceImpactSimulator.Persistence/CsvSink.cs
+++ b/PriceImpactSimulator.Persistence/CsvSink.cs
@@ -12,6 +12,7 @@ public sealed class CsvSink : IDisposable
 {
     private readonly StreamWriter _trades;
     private readonly StreamWriter _orders;
+    private readonly StreamWriter _books;
 
     public CsvSink(string folderUtc)
     {
@@ -23,6 +24,8 @@ public sealed class CsvSink : IDisposable
             "ts,side,price,qty");
         _orders = Create(Path.Combine(folderUtc, $"orders_{stamp}.csv"),
             "ts,orderId,execType,side,price,lastQty,leaves");
+        _books = Create(Path.Combine(folderUtc, $"book_{stamp}.csv"),
+            "ts,side,price,qty");
 
         static StreamWriter Create(string path, string header)
         {
@@ -41,10 +44,19 @@ public sealed class CsvSink : IDisposable
         _orders.WriteLine($"{e.Timestamp:O},{e.OrderId},{e.ExecType},{e.Side}," +
                           $"{e.Price:F2},{e.LastQty},{e.LeavesQty}");
 
+    public void LogBook(in OrderBookSnapshot snap)
+    {
+        foreach (var l in snap.Bids)
+            _books.WriteLine($"{snap.Timestamp:O},Bid,{l.Price:F2},{l.Quantity}");
+        foreach (var l in snap.Asks)
+            _books.WriteLine($"{snap.Timestamp:O},Ask,{l.Price:F2},{l.Quantity}");
+    }
+
     // ---------- housekeeping ----------
     public void Dispose()
     {
         _trades.Dispose();
         _orders.Dispose();
+        _books.Dispose();
     }
 }

--- a/PriceImpactSimulator.Strategies/DripAccumThenDumpStrategy.cs
+++ b/PriceImpactSimulator.Strategies/DripAccumThenDumpStrategy.cs
@@ -1,0 +1,97 @@
+﻿using System;
+using System.Collections.Generic;
+using PriceImpactSimulator.Domain;
+using PriceImpactSimulator.StrategyApi;
+
+namespace PriceImpactSimulator.Strategies;
+
+/// <summary>
+/// 1. After a 40‑sec warm‑up, buys a tiny slice at market every tick.
+/// 2. If best Bid ≥ VWAP + €0.05 **or** ≤ VWAP − €0.02, flattens entire position
+///    with ONE market order (price = 0).  Buying‑power is reset.
+/// </summary>
+public sealed class DripAccumThenDumpStrategy : IStrategy, IStrategyWithStats
+{
+    // ---- params ---------------------------------------------------------
+    private const int SliceQty = 1; // per‑tick buy size
+    private const decimal TakeProf = 0.05m; // +5 cts over VWAP
+    private const decimal StopLoss = 0.02m; // −2 cts under VWAP
+    private static readonly TimeSpan StartDelay = TimeSpan.FromSeconds(10);
+
+    // ---- runtime state --------------------------------------------------
+    private StrategyContext _ctx = null!;
+    private DateTime _start;
+    private int _position;
+    private decimal _vwap; // running volume‑weighted average buy price
+    private decimal _lastBestBid;
+    private decimal _realised;
+    private readonly HashSet<Guid> _myOrders = new();
+
+    // ---- metrics exposure ----------------------------------------------
+    public StrategyMetrics Metrics => new(
+        BuyingPowerUsed: _position * _vwap,
+        Position: _position,
+        Vwap: _position > 0 ? _vwap : 0m,
+        PnL: _realised + _position * (_lastBestBid - _vwap),
+        RealisedPnL: _realised);
+
+    // --------------------------------------------------------------------
+    public void Initialize(in StrategyContext ctx)
+    {
+        _ctx = ctx;
+        _start = DateTime.UtcNow;
+        _ctx.Logger("DripAccumThenDumpStrategy armed; will start after 40 s.");
+    }
+
+    public void OnOrderBook(in OrderBookSnapshot snap)
+    {
+        if (snap.Bids.Length > 0) _lastBestBid = snap.Bids[0].Price;
+    }
+
+    public void OnExecution(in ExecutionReport rep)
+    {
+        if (!_myOrders.Contains(rep.OrderId)) return;
+        
+        if (rep.ExecType != ExecType.Trade || rep.LastQty == 0) return;
+        if (rep.Side == Side.Buy)
+        {
+            int prevPos = _position;
+            _position += rep.LastQty;
+            _vwap = prevPos == 0
+                ? rep.Price
+                : (_vwap * prevPos + rep.Price * rep.LastQty) / _position;
+        }
+        else if (rep.Side == Side.Sell)
+        {
+            _realised += rep.LastQty * (rep.Price - _vwap);
+
+            _position -= rep.LastQty;
+            if (_position <= 0)
+            {
+                _position = 0;
+                _vwap = 0m;
+            }
+        }
+    }
+
+    public IReadOnlyList<OrderCommand> GenerateCommands(DateTime nowUtc)
+    {
+        // Not started yet?
+        if (nowUtc - _start < StartDelay) return Array.Empty<OrderCommand>();
+
+        // 1) Check flatten conditions
+        if (_position > 0 &&
+            (_lastBestBid >= _vwap + TakeProf || _lastBestBid <= _vwap - StopLoss))
+        {
+            _ctx.Logger($"Flattening {_position} @ market (bid={_lastBestBid:F2}, vwap={_vwap:F2})");
+            var id = Guid.NewGuid();
+            _myOrders.Add(id);
+            return new[] { OrderCommand.New(id, Side.Sell, 0m, _position) }; // price 0 ⇒ market
+        }
+
+        // 2) Otherwise, drip‑buy a small slice each tick
+        var buyId = Guid.NewGuid();
+        _myOrders.Add(buyId);
+        return new[] { OrderCommand.New(buyId, Side.Buy, 0m, SliceQty) };
+    }
+}

--- a/PriceImpactSimulator.Strategies/LadderBidStrategy.cs
+++ b/PriceImpactSimulator.Strategies/LadderBidStrategy.cs
@@ -44,7 +44,8 @@ public sealed class LadderBidStrategy : IStrategy, IStrategyWithStats
 
     public void OnExecution(in ExecutionReport report)
     {
-        var idx = _orders.FindIndex(o => o.id == report.OrderId);
+        var orderId = report.OrderId;
+        var idx = _orders.FindIndex(o => o.id == orderId);
         if (idx >= 0 && report.ExecType == ExecType.Trade && report.LastQty > 0)
         {
             int prevPos = _position;

--- a/PriceImpactSimulator.Strategies/LadderBidStrategy.cs
+++ b/PriceImpactSimulator.Strategies/LadderBidStrategy.cs
@@ -1,0 +1,113 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using PriceImpactSimulator.Domain;
+using PriceImpactSimulator.StrategyApi;
+
+namespace PriceImpactSimulator.Strategies;
+
+public sealed class LadderBidStrategy : IStrategy, IStrategyWithStats
+{
+    private StrategyContext _ctx = null!;
+    private DateTime _startTime;
+    private readonly TimeSpan _delay = TimeSpan.FromSeconds(30);
+
+    private readonly List<(Guid id, decimal price)> _orders = new();
+
+    private decimal _lastBestBid;
+    private decimal _lastMid;
+
+    private int _position;
+    private decimal _vwap;
+
+    public StrategyMetrics Metrics => new(
+        BuyingPowerUsed: _position * _vwap,
+        Position: _position,
+        Vwap: _position > 0 ? _vwap : 0m,
+        PnL: _position * (_lastMid - (_position > 0 ? _vwap : 0m))
+    );
+
+    public void Initialize(in StrategyContext ctx)
+    {
+        _ctx = ctx;
+        _startTime = DateTime.UtcNow;
+        _ctx.Logger($"LadderBidStrategy initialized at {_startTime:O}");
+    }
+
+    public void OnOrderBook(in OrderBookSnapshot snapshot)
+    {
+        if (snapshot.Bids.Length > 0)
+            _lastBestBid = snapshot.Bids[0].Price;
+        if (snapshot.Bids.Length > 0 && snapshot.Asks.Length > 0)
+            _lastMid = (snapshot.Bids[0].Price + snapshot.Asks[0].Price) / 2m;
+    }
+
+    public void OnExecution(in ExecutionReport report)
+    {
+        var idx = _orders.FindIndex(o => o.id == report.OrderId);
+        if (idx >= 0 && report.ExecType == ExecType.Trade && report.LastQty > 0)
+        {
+            int prevPos = _position;
+            _position += report.LastQty;
+            _vwap = prevPos == 0
+                ? report.Price
+                : (_vwap * prevPos + report.Price * report.LastQty) / _position;
+            _ctx.Logger($"Fill {report.LastQty} @ {report.Price:F2}; pos={_position}");
+            if (report.LeavesQty == 0)
+                _orders.RemoveAt(idx);
+        }
+        else if (idx >= 0 && report.ExecType == ExecType.Cancel)
+        {
+            _orders.RemoveAt(idx);
+            _ctx.Logger($"Canceled {report.OrderId}");
+        }
+    }
+
+    public IReadOnlyList<OrderCommand> GenerateCommands(DateTime utcNow)
+    {
+        if (utcNow - _startTime < _delay || _lastBestBid == 0m)
+            return Array.Empty<OrderCommand>();
+
+        if (_orders.Count == 0)
+            return PlaceLadder(_lastBestBid - _ctx.TickSize);
+
+        decimal myTop = _orders.Max(o => o.price);
+        decimal diff = _lastBestBid - myTop;
+
+        if (diff <= 0m)
+            return ShiftLadder(myTop - _ctx.TickSize, "down");
+        if (diff > _ctx.TickSize)
+            return ShiftLadder(myTop + _ctx.TickSize, "up");
+
+        return Array.Empty<OrderCommand>();
+    }
+
+    private IReadOnlyList<OrderCommand> PlaceLadder(decimal startPrice)
+    {
+        _ctx.Logger($"Placing ladder from {startPrice:F2}");
+        const int levels = 5;
+        const double lambda = 0.5;
+        const int baseQty = 1000;
+        var cmds = new List<OrderCommand>(levels);
+        _orders.Clear();
+        for (int i = 0; i < levels; i++)
+        {
+            var price = startPrice - i * _ctx.TickSize;
+            var qty = (int)Math.Round(baseQty * Math.Exp(-lambda * i));
+            var id = Guid.NewGuid();
+            cmds.Add(OrderCommand.New(id, Side.Buy, price, qty));
+            _orders.Add((id, price));
+        }
+        return cmds;
+    }
+
+    private IReadOnlyList<OrderCommand> ShiftLadder(decimal newStart, string dir)
+    {
+        _ctx.Logger($"Shifting ladder {dir} to start {newStart:F2}");
+        var cancel = _orders.Select(o => OrderCommand.Cancel(o.id)).ToList();
+        var place = PlaceLadder(newStart);
+        cancel.AddRange(place);
+        return cancel;
+    }
+}
+

--- a/PriceImpactSimulator.StrategyApi/IStrategyWithStats.cs
+++ b/PriceImpactSimulator.StrategyApi/IStrategyWithStats.cs
@@ -1,0 +1,6 @@
+namespace PriceImpactSimulator.StrategyApi;
+
+public interface IStrategyWithStats : IStrategy
+{
+    StrategyMetrics Metrics { get; }
+}

--- a/PriceImpactSimulator.StrategyApi/OrderCommand.cs
+++ b/PriceImpactSimulator.StrategyApi/OrderCommand.cs
@@ -10,4 +10,11 @@ public sealed record OrderCommand
     Side        Side     = Side.Buy,
     decimal     Price    = 0m,
     int         Quantity = 0
-);
+)
+{
+    public static OrderCommand New(Guid id, Side side, decimal price, int qty) =>
+        new(CommandType.New, id, side, price, qty);
+
+    public static OrderCommand Cancel(Guid id) =>
+        new(CommandType.Cancel, id);
+}

--- a/PriceImpactSimulator.StrategyApi/StrategyMetrics.cs
+++ b/PriceImpactSimulator.StrategyApi/StrategyMetrics.cs
@@ -1,0 +1,8 @@
+namespace PriceImpactSimulator.StrategyApi;
+
+public readonly record struct StrategyMetrics(
+    decimal BuyingPowerUsed,
+    int     Position,
+    decimal Vwap,
+    decimal PnL
+);

--- a/PriceImpactSimulator.StrategyApi/StrategyMetrics.cs
+++ b/PriceImpactSimulator.StrategyApi/StrategyMetrics.cs
@@ -4,5 +4,6 @@ public readonly record struct StrategyMetrics(
     decimal BuyingPowerUsed,
     int     Position,
     decimal Vwap,
-    decimal PnL
+    decimal PnL,
+    decimal RealisedPnL
 );

--- a/PriceImpactSimulator.Tests/MarketSimulatorTests.cs
+++ b/PriceImpactSimulator.Tests/MarketSimulatorTests.cs
@@ -38,4 +38,24 @@ public class MarketSimulatorTests
         sim.Step(ts);
         Assert.NotEqual(midBefore, book.Mid);
     }
+
+    [Fact]
+    public void Snapshot_Is_Sorted()
+    {
+        var book = new OrderBook();
+        var ts = DateTime.UtcNow;
+
+        book.AddLimit(new Order(Guid.NewGuid(), ts, Side.Buy, 19.95m, 100, OrderType.Limit, null));
+        book.AddLimit(new Order(Guid.NewGuid(), ts, Side.Buy, 19.97m, 100, OrderType.Limit, null));
+        book.AddLimit(new Order(Guid.NewGuid(), ts, Side.Buy, 19.96m, 100, OrderType.Limit, null));
+
+        book.AddLimit(new Order(Guid.NewGuid(), ts, Side.Sell, 20.05m, 100, OrderType.Limit, null));
+        book.AddLimit(new Order(Guid.NewGuid(), ts, Side.Sell, 20.02m, 100, OrderType.Limit, null));
+        book.AddLimit(new Order(Guid.NewGuid(), ts, Side.Sell, 20.03m, 100, OrderType.Limit, null));
+
+        var snap = book.Snapshot(ts, 3);
+
+        Assert.Equal(new[] { 19.97m, 19.96m, 19.95m }, snap.Bids.Select(b => b.Price));
+        Assert.Equal(new[] { 20.02m, 20.03m, 20.05m }, snap.Asks.Select(a => a.Price));
+    }
 }

--- a/PriceImpactSimulator.Tests/MarketSimulatorTests.cs
+++ b/PriceImpactSimulator.Tests/MarketSimulatorTests.cs
@@ -30,8 +30,8 @@ public class MarketSimulatorTests
 
         for (int d = 0; d < 5; d++)
         {
-            book.AddLimit(new Order(Guid.NewGuid(), ts, Side.Sell, 20.01m + d * 0.01m, 1000, OrderType.Limit, null));
-            book.AddLimit(new Order(Guid.NewGuid(), ts, Side.Buy, 19.99m - d * 0.01m, 1000, OrderType.Limit, null));
+            book.AddLimit(new Order(Guid.NewGuid(), ts, Side.Sell, 20.01m + d * 0.01m, 1000, OrderType.Limit, null), ts);
+            book.AddLimit(new Order(Guid.NewGuid(), ts, Side.Buy, 19.99m - d * 0.01m, 1000, OrderType.Limit, null), ts);
         }
 
         var midBefore = book.Mid;
@@ -45,13 +45,13 @@ public class MarketSimulatorTests
         var book = new OrderBook();
         var ts = DateTime.UtcNow;
 
-        book.AddLimit(new Order(Guid.NewGuid(), ts, Side.Buy, 19.95m, 100, OrderType.Limit, null));
-        book.AddLimit(new Order(Guid.NewGuid(), ts, Side.Buy, 19.97m, 100, OrderType.Limit, null));
-        book.AddLimit(new Order(Guid.NewGuid(), ts, Side.Buy, 19.96m, 100, OrderType.Limit, null));
+        book.AddLimit(new Order(Guid.NewGuid(), ts, Side.Buy, 19.95m, 100, OrderType.Limit, null), ts);
+        book.AddLimit(new Order(Guid.NewGuid(), ts, Side.Buy, 19.97m, 100, OrderType.Limit, null), ts);
+        book.AddLimit(new Order(Guid.NewGuid(), ts, Side.Buy, 19.96m, 100, OrderType.Limit, null), ts);
 
-        book.AddLimit(new Order(Guid.NewGuid(), ts, Side.Sell, 20.05m, 100, OrderType.Limit, null));
-        book.AddLimit(new Order(Guid.NewGuid(), ts, Side.Sell, 20.02m, 100, OrderType.Limit, null));
-        book.AddLimit(new Order(Guid.NewGuid(), ts, Side.Sell, 20.03m, 100, OrderType.Limit, null));
+        book.AddLimit(new Order(Guid.NewGuid(), ts, Side.Sell, 20.05m, 100, OrderType.Limit, null), ts);
+        book.AddLimit(new Order(Guid.NewGuid(), ts, Side.Sell, 20.02m, 100, OrderType.Limit, null), ts);
+        book.AddLimit(new Order(Guid.NewGuid(), ts, Side.Sell, 20.03m, 100, OrderType.Limit, null), ts);
 
         var snap = book.Snapshot(ts, 3);
 

--- a/PriceImpactSimulator/Program.cs
+++ b/PriceImpactSimulator/Program.cs
@@ -5,7 +5,7 @@ using PriceImpactSimulator.Strategies;
 using PriceImpactSimulator.Engine;
 
 // simulation tick aligned with README specification
-var step = TimeSpan.FromMilliseconds(100);
+var step = TimeSpan.FromMilliseconds(10);
 
 var ctx = new StrategyContext
 {
@@ -18,21 +18,23 @@ var ctx = new StrategyContext
 var simParams = new MarketSimulator.SimParams(
     TickSize:      0.01m,
     StartMidPrice: 20.00m,
-    CancelProb:    0.01,
-    TrendLookback: 10,
-    PriceLookback: 10,
-    K1Imbalance:   0.60,
-    K2Trend:       0.50,
-    K3PriceDev:    0.15,
+    CancelProb:    0.005,
+    TrendLookback: 20,
+    PriceLookback: 20,
+    K1Imbalance: 0.40,
+    K2Trend    : 0.25,
+    K3PriceDev : 0.15,
     LambdaDepth:   0.15,
     Q0:            2500,
     LogNormMu:     7,
     LogNormSigma:  1.1,
     Seed:          42);
 
+//var strat1 = new LadderBidStrategy();
+var strat2 = new DripAccumThenDumpStrategy();
 
-var strategy = new LadderBidStrategy();
-var runner   = new SimulationRunner(strategy, simParams, ctx, logFolder: "logs");
+var runner = new SimulationRunner(strat2, simParams, ctx, "logs");
+
 
 runner.Run(TimeSpan.FromMinutes(1));
 

--- a/PriceImpactSimulator/Program.cs
+++ b/PriceImpactSimulator/Program.cs
@@ -4,7 +4,8 @@ using PriceImpactSimulator.StrategyApi;
 using PriceImpactSimulator.Strategies;
 using PriceImpactSimulator.Engine;
 
-var step = TimeSpan.FromMilliseconds(10);
+// simulation tick aligned with README specification
+var step = TimeSpan.FromMilliseconds(100);
 
 var ctx = new StrategyContext
 {
@@ -17,14 +18,14 @@ var ctx = new StrategyContext
 var simParams = new MarketSimulator.SimParams(
     TickSize:      0.01m,
     StartMidPrice: 20.00m,
-    CancelProb:    0.005,
+    CancelProb:    0.01,
     TrendLookback: 10,
     PriceLookback: 10,
-    K1Imbalance:   0.55,
-    K2Trend:       0.35,
-    K3PriceDev:    0.25,
-    LambdaDepth:   0.2,
-    Q0:            3000,
+    K1Imbalance:   0.60,
+    K2Trend:       0.50,
+    K3PriceDev:    0.15,
+    LambdaDepth:   0.15,
+    Q0:            2500,
     LogNormMu:     7,
     LogNormSigma:  1.1,
     Seed:          42);

--- a/PriceImpactSimulator/Program.cs
+++ b/PriceImpactSimulator/Program.cs
@@ -31,7 +31,7 @@ var simParams = new MarketSimulator.SimParams(
     Seed:          42);
 
 
-var strategy = new NoOpStrategy(); 
+var strategy = new LadderBidStrategy();
 var runner   = new SimulationRunner(strategy, simParams, ctx, logFolder: "logs");
 
 runner.Run(TimeSpan.FromMinutes(1));


### PR DESCRIPTION
## Summary
- align tick step with README (100 ms)
- seed orderbook around StartMidPrice using exponential depth
- refill best levels when top liquidity drops
- log order book snapshots every 10 seconds
- tweak simulator parameters for more activity

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f5075db5c83308f7b9bfd4eec977c